### PR TITLE
add ListenWithID and StopListening

### DIFF
--- a/event.go
+++ b/event.go
@@ -22,9 +22,7 @@ type Event[T any] struct {
 
 // New creates and returns a new Event instance for the specified type T.
 func New[T any]() *Event[T] {
-	return &Event[T]{
-		listeners: make(map[int]func(T)),
-	}
+	return &Event[T]{}
 }
 
 // Trigger notifies all registered listeners by invoking their callback functions with the provided value.
@@ -66,7 +64,6 @@ func (e *Event[T]) Trigger(value T) error {
 func (e *Event[T]) Listen(f func(T)) error {
 	_, err := e.ListenWithID(f)
 	return err
-
 }
 
 // ListenWithID registers a new listener callback function for the event.
@@ -77,6 +74,11 @@ func (e *Event[T]) Listen(f func(T)) error {
 func (e *Event[T]) ListenWithID(f func(T)) (int, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+
+	// Lazy init to allow use of zero value
+	if e.listeners == nil {
+		e.listeners = make(map[int]func(T))
+	}
 
 	if e.closed {
 		return -1, ErrEventClosed

--- a/event.go
+++ b/event.go
@@ -8,7 +8,7 @@ import (
 // ErrEventClosed is returned when an operation is attempted on a closed event.
 var ErrEventClosed = errors.New("event is closed")
 
-// ErrUnknownListener is returned when attempting to unregister an unknown id
+// ErrUnknownListener is returned when attempting to unregister an unknown id.
 var ErrUnknownListener = errors.New("listener id is unknown")
 
 // Event represents a generic, thread-safe event system that can handle multiple listeners.

--- a/event.go
+++ b/event.go
@@ -39,7 +39,7 @@ func (e *Event[T]) Trigger(value T) error {
 
 	// Copy the listeners to avoid holding the lock during execution.
 	// This ensures that triggering the event is thread-safe even if listeners are added or removed concurrently.
-	var listeners []func(T)
+	listeners := make([]func(T), 0, len(e.listeners))
 	for _, l := range e.listeners {
 		listeners = append(listeners, l)
 	}

--- a/event.go
+++ b/event.go
@@ -91,6 +91,9 @@ func (e *Event[T]) ListenWithID(f func(T)) (int, error) {
 	return id, nil
 }
 
+// StopListening unregisters a listener, using the ID returned from Listen.
+// The callback which was registered with that ID will no longer be called
+// and any associated resources will be released.
 func (e *Event[T]) StopListening(id int) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/event.go
+++ b/event.go
@@ -17,7 +17,7 @@ type Event[T any] struct {
 	listeners map[int]func(T)
 	mu        sync.RWMutex
 	closed    bool
-	next_id   int
+	nextID    int
 }
 
 // New creates and returns a new Event instance for the specified type T.
@@ -102,8 +102,8 @@ func (e *Event[T]) StopListening(id int) error {
 }
 
 func (e *Event[T]) getID() int {
-	id := e.next_id
-	e.next_id++
+	id := e.nextID
+	e.nextID++
 	return id
 }
 

--- a/event.go
+++ b/event.go
@@ -60,18 +60,9 @@ func (e *Event[T]) Trigger(value T) error {
 
 // Listen registers a new listener callback function for the event.
 // The listener will be invoked with the event's data whenever Trigger is called.
+// Returns an ID which can be used with StopListening to deregister the listener.
 // Returns ErrEventClosed if the event has been closed.
-func (e *Event[T]) Listen(f func(T)) error {
-	_, err := e.ListenWithID(f)
-	return err
-}
-
-// ListenWithID registers a new listener callback function for the event.
-// The listener will be invoked with the event's data whenever Trigger is called.
-// Returns ErrEventClosed if the event has been closed.
-// It behaves exactly as Listen, but also returns an ID which can be used
-// with StopListening to deregister the listener
-func (e *Event[T]) ListenWithID(f func(T)) (int, error) {
+func (e *Event[T]) Listen(f func(T)) (int, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -94,6 +85,7 @@ func (e *Event[T]) ListenWithID(f func(T)) (int, error) {
 // StopListening unregisters a listener, using the ID returned from Listen.
 // The callback which was registered with that ID will no longer be called
 // and any associated resources will be released.
+// If the ID passed in is not registered, ErrUnknownListener will be returned.
 func (e *Event[T]) StopListening(id int) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/event.go
+++ b/event.go
@@ -8,17 +8,23 @@ import (
 // ErrEventClosed is returned when an operation is attempted on a closed event.
 var ErrEventClosed = errors.New("event is closed")
 
+// ErrUnknownListener is returned when attempting to unregister an unknown id
+var ErrUnknownListener = errors.New("listener id is unknown")
+
 // Event represents a generic, thread-safe event system that can handle multiple listeners.
 // The type parameter T specifies the type of data that the event carries when triggered.
 type Event[T any] struct {
-	listeners []func(T)
+	listeners map[int]func(T)
 	mu        sync.RWMutex
 	closed    bool
+	next_id   int
 }
 
 // New creates and returns a new Event instance for the specified type T.
 func New[T any]() *Event[T] {
-	return &Event[T]{}
+	return &Event[T]{
+		listeners: make(map[int]func(T)),
+	}
 }
 
 // Trigger notifies all registered listeners by invoking their callback functions with the provided value.
@@ -33,8 +39,10 @@ func (e *Event[T]) Trigger(value T) error {
 
 	// Copy the listeners to avoid holding the lock during execution.
 	// This ensures that triggering the event is thread-safe even if listeners are added or removed concurrently.
-	listeners := make([]func(T), len(e.listeners))
-	copy(listeners, e.listeners)
+	var listeners []func(T)
+	for _, l := range e.listeners {
+		listeners = append(listeners, l)
+	}
 	e.mu.RUnlock()
 
 	var wg sync.WaitGroup
@@ -56,16 +64,47 @@ func (e *Event[T]) Trigger(value T) error {
 // The listener will be invoked with the event's data whenever Trigger is called.
 // Returns ErrEventClosed if the event has been closed.
 func (e *Event[T]) Listen(f func(T)) error {
+	_, err := e.ListenWithID(f)
+	return err
+
+}
+
+// ListenWithID registers a new listener callback function for the event.
+// The listener will be invoked with the event's data whenever Trigger is called.
+// Returns ErrEventClosed if the event has been closed.
+// It behaves exactly as Listen, but also returns an ID which can be used
+// with StopListening to deregister the listener
+func (e *Event[T]) ListenWithID(f func(T)) (int, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	if e.closed {
-		return ErrEventClosed
+		return -1, ErrEventClosed
 	}
 
-	e.listeners = append(e.listeners, f)
+	id := e.getID()
 
+	e.listeners[id] = f
+
+	return id, nil
+}
+
+func (e *Event[T]) StopListening(id int) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	_, ok := e.listeners[id]
+	if !ok {
+		return ErrUnknownListener
+	}
+	delete(e.listeners, id)
 	return nil
+}
+
+func (e *Event[T]) getID() int {
+	id := e.next_id
+	e.next_id++
+	return id
 }
 
 // Close closes the event system, preventing any new listeners from being added or events from being triggered.

--- a/event_test.go
+++ b/event_test.go
@@ -1,1 +1,10 @@
 package event
+
+import "testing"
+
+func TestZeroValue(t *testing.T) {
+	var ev Event[string]
+
+	// Can listen to zero value without panicing
+	ev.Listen(func(v string) { println(v) })
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -90,7 +90,7 @@ func ExampleEvent_StopListening() {
 
 	// Listen to the event
 	triggerCount := 0
-	listen_id, _ := exampleEvent.ListenWithID(func(v string) {
+	listenID, _ := exampleEvent.ListenWithID(func(v string) {
 		triggerCount++
 		fmt.Printf("%d - %s\n", triggerCount, v)
 	})
@@ -106,7 +106,7 @@ func ExampleEvent_StopListening() {
 	delay()
 
 	// Stop listening
-	exampleEvent.StopListening(listen_id)
+	exampleEvent.StopListening(listenID)
 
 	// Trigger the event again
 	exampleEvent.Trigger("foo")

--- a/examples_test.go
+++ b/examples_test.go
@@ -85,7 +85,6 @@ func ExampleEvent_Close() {
 }
 
 func ExampleEvent_StopListening() {
-
 	// Create a new event
 	exampleEvent := event.New[string]()
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -83,3 +83,44 @@ func ExampleEvent_Close() {
 	// 2
 	// 3
 }
+
+func ExampleEvent_StopListening() {
+
+	// Create a new event
+	exampleEvent := event.New[string]()
+
+	// Listen to the event
+	triggerCount := 0
+	listen_id, _ := exampleEvent.ListenWithID(func(v string) {
+		triggerCount++
+		fmt.Printf("%d - %s\n", triggerCount, v)
+	})
+
+	// Trigger the event
+	exampleEvent.Trigger("foo")
+	delay() // delay for deterministic output
+	exampleEvent.Trigger("bar")
+	delay() // delay for deterministic output
+	exampleEvent.Trigger("baz")
+
+	// Time for listeners to process the event
+	delay()
+
+	// Stop listening
+	exampleEvent.StopListening(listen_id)
+
+	// Trigger the event again
+	exampleEvent.Trigger("foo")
+	delay() // delay for deterministic output
+	exampleEvent.Trigger("bar")
+	delay() // delay for deterministic output
+	exampleEvent.Trigger("baz")
+
+	// Keep the program alive
+	time.Sleep(time.Second)
+
+	// Output:
+	// 1 - foo
+	// 2 - bar
+	// 3 - baz
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -90,7 +90,7 @@ func ExampleEvent_StopListening() {
 
 	// Listen to the event
 	triggerCount := 0
-	listenID, _ := exampleEvent.ListenWithID(func(v string) {
+	listenID, _ := exampleEvent.Listen(func(v string) {
 		triggerCount++
 		fmt.Printf("%d - %s\n", triggerCount, v)
 	})


### PR DESCRIPTION
Hi,

Thanks very much for this library. I wanted to use it to push events out of a websocket, but also wanted to avoid leaking a listener (and any associated resources) if the websocket closed, so I added `ListenWithID` and `StopListening` to allow unregistering a listener.

I chose to avoid changing `Listen` to return an id, since that was a backwards-incompatible change.

Thanks again.

regards,

jb